### PR TITLE
V0.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,15 +41,15 @@ A [Postman](https://www.postman.com/)-like API client for [protobuf](https://dev
 
 ### Mac
 
-[Protoman-0.3.0.dmg](https://github.com/spluxx/Protoman/releases/download/v0.3.0/Protoman-0.3.0.dmg)
+[Protoman-0.3.1.dmg](https://github.com/spluxx/Protoman/releases/download/v0.3.1/Protoman-0.3.1.dmg)
 
 ### Windows
 
-[Protoman Setup 0.3.0.exe](https://github.com/spluxx/Protoman/releases/download/v0.3.0/Protoman.Setup.0.3.0.exe) - Unlike mac, I don't currently own a license to sign the app. So it might give you some security warnings!
+[Protoman Setup 0.3.1.exe](https://github.com/spluxx/Protoman/releases/download/v0.3.1/Protoman.Setup.0.3.1.exe) - Unlike mac, I don't currently own a license to sign the app. So it might give you some security warnings!
 
 ### Linux
 
-[Protoman-0.3.0.AppImage](https://github.com/spluxx/Protoman/releases/download/v0.3.0/Protoman-0.3.0.AppImage)
+[Protoman-0.3.1.AppImage](https://github.com/spluxx/Protoman/releases/download/v0.3.1/Protoman-0.3.1.AppImage)
 
 As a fallback, you can clone the repo and run npm install && npm run build to build, and npm run start to launch the app. Or, you can actually find configurations on [electron builder](https://www.electron.build/) to get the right distribution version yourself!
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Protoman",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Basic Postman clone with protobuf functionalities",
   "author": "Inchan Hwang, Louis Lee",
   "license": "MIT",

--- a/src/renderer/components/Flow/body/MessageValueView.tsx
+++ b/src/renderer/components/Flow/body/MessageValueView.tsx
@@ -282,7 +282,7 @@ const OneOfFieldView: FunctionComponent<OFVProps> = ({
     <Block>
       <FieldName>{fieldName}</FieldName>
       <span>: </span>
-      {editable ? (
+      {editable && (
         <Select
           value={name}
           size="small"
@@ -295,8 +295,6 @@ const OneOfFieldView: FunctionComponent<OFVProps> = ({
             </Select.Option>
           ))}
         </Select>
-      ) : (
-        <span>{`${name} (${value.type.name})`}</span>
       )}
       <IndentationBlock>
         <SingleFieldView editable={editable} fieldName={name} value={value} handlers={prefix(name, handlers)} />


### PR DESCRIPTION
+ Remove redundant type specifier
+ protobuf strips off "empty" values so checking them on primitive / repeated values is necessary. Not setting an oneof field should be considered an error though.