### PR TITLE
Issue-80 Use includes for Content_type_json instead of strict equals

### DIFF
--- a/src/core/http_client/client.ts
+++ b/src/core/http_client/client.ts
@@ -47,7 +47,7 @@ async function translateResponse(
   if (buf.length === 0) {
     responseBodyType = 'empty';
     responseBodyValue = undefined;
-  } else if (saidContentType === CONTENT_TYPE_JSON) {
+  } else if (saidContentType?.includes(CONTENT_TYPE_JSON)) {
     responseBodyType = 'json';
     responseBodyValue = toJson(buf);
   } else if (saidContentType?.includes(CONTENT_TYPE_HTML)) {


### PR DESCRIPTION
Relating to my issue: **Json ContentType with ;charset=utf-8 is not recognized**

The fix is to use includes instead of strict comparison